### PR TITLE
chore: Return literal numbers within a `$literal` stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,5 @@ console.log( JSON.stringify(mql) );
 This would output
 
 ```
-{"$sum":["$foo",1]}
+{"$sum": ["$foo", {$literal: 1}]}
 ```

--- a/esm/expr-to-mql.js
+++ b/esm/expr-to-mql.js
@@ -27,7 +27,9 @@ var unaryExpressionFn = function unaryExpressionFn(node) {
 
 
   if (node.argument.type === 'Literal' && isNumber(node.argument.value)) {
-    return -node.argument.value;
+    return {
+      $literal: -node.argument.value
+    };
   } // flatten nested unary expressions
 
 
@@ -38,13 +40,19 @@ var unaryExpressionFn = function unaryExpressionFn(node) {
 
 
   return {
-    $multiply: [-1, mapNodeToMQL(node.argument)]
+    $multiply: [{
+      $literal: -1
+    }, mapNodeToMQL(node.argument)]
   };
 }; // expression builder function for Literal nodes
 
 
 var literalExpressionFn = function literalExpressionFn(node) {
-  return isNumber(node.value) ? node.value : "$".concat(node.value);
+  return (// return numbers within a `$literal` stage
+    isNumber(node.value) ? {
+      $literal: node.value
+    } : "$".concat(node.value)
+  );
 }; // expression builder function for Identifier nodes
 
 

--- a/lib/expr-to-mql.js
+++ b/lib/expr-to-mql.js
@@ -35,7 +35,9 @@ const unaryExpressionFn = node => {
 
 
   if (node.argument.type === 'Literal' && (0, _lodash.isNumber)(node.argument.value)) {
-    return -node.argument.value;
+    return {
+      $literal: -node.argument.value
+    };
   } // flatten nested unary expressions
 
 
@@ -46,12 +48,17 @@ const unaryExpressionFn = node => {
 
 
   return {
-    $multiply: [-1, mapNodeToMQL(node.argument)]
+    $multiply: [{
+      $literal: -1
+    }, mapNodeToMQL(node.argument)]
   };
 }; // expression builder function for Literal nodes
 
 
-const literalExpressionFn = node => (0, _lodash.isNumber)(node.value) ? node.value : `$${node.value}`; // expression builder function for Identifier nodes
+const literalExpressionFn = node => // return numbers within a `$literal` stage
+(0, _lodash.isNumber)(node.value) ? {
+  $literal: node.value
+} : `$${node.value}`; // expression builder function for Identifier nodes
 
 
 const identifierExpressionFn = node => `$${node.name}`; // maps AST node types to their expression builder functions

--- a/src/expr-to-mql.js
+++ b/src/expr-to-mql.js
@@ -26,7 +26,7 @@ const unaryExpressionFn = node => {
   }
   // for literals, we can return the negative value
   if (node.argument.type === 'Literal' && isNumber(node.argument.value)) {
-    return -node.argument.value;
+    return { $literal: -node.argument.value };
   }
   // flatten nested unary expressions
   if (node.argument.type === 'UnaryExpression') {
@@ -34,12 +34,13 @@ const unaryExpressionFn = node => {
     return mapNodeToMQL(node.argument);
   }
   // for everything else, multiply with -1 in the agg framework
-  return { $multiply: [-1, mapNodeToMQL(node.argument)] };
+  return { $multiply: [{ $literal: -1 }, mapNodeToMQL(node.argument)] };
 };
 
 // expression builder function for Literal nodes
 const literalExpressionFn = node =>
-  isNumber(node.value) ? node.value : `$${node.value}`;
+  // return numbers within a `$literal` stage
+  isNumber(node.value) ? { $literal: node.value } : `$${node.value}`;
 
 // expression builder function for Identifier nodes
 const identifierExpressionFn = node => `$${node.name}`;

--- a/test/expr-to-mql.spec.js
+++ b/test/expr-to-mql.spec.js
@@ -4,76 +4,106 @@ import { expect } from 'chai';
 describe('exprToMQL', function() {
   it('works for numeric literals', function() {
     const mql = exprToMQL('1 + 2');
-    expect(mql).to.be.deep.equal({ $sum: [1, 2] });
+    expect(mql).to.be.deep.equal({
+      $sum: [{ $literal: 1 }, { $literal: 2 }]
+    });
   });
+
   it('flattens repeated unary operators', function() {
     const mql = exprToMQL('--1 - --1');
-    expect(mql).to.be.deep.equal({ $subtract: [1, 1] });
+    expect(mql).to.be.deep.equal({
+      $subtract: [{ $literal: 1 }, { $literal: 1 }]
+    });
   });
+
   it('works for string literals', function() {
     const mql = exprToMQL('"field" + "other"');
     expect(mql).to.be.deep.equal({ $sum: ['$field', '$other'] });
   });
+
   it('works for string literals with spaces', function() {
     const mql = exprToMQL('"some field" / 2');
-    expect(mql).to.be.deep.equal({ $divide: ['$some field', 2] });
+    expect(mql).to.be.deep.equal({ $divide: ['$some field', { $literal: 2 }] });
   });
+
   it('throws for invalid literal types', function() {
     expect(exprToMQL.bind(null, '3 + false')).to.throw(
       /Invalid literal type "boolean"/
     );
   });
+
   it('works for identifiers', function() {
     const mql = exprToMQL('var1 + var2');
     expect(mql).to.be.deep.equal({ $sum: ['$var1', '$var2'] });
   });
+
   it('works for identifiers with underscores and capital letters', function() {
     const mql = exprToMQL('My_Var + YOUR_VAR');
     expect(mql).to.be.deep.equal({ $sum: ['$My_Var', '$YOUR_VAR'] });
   });
+
   it('throws for identifiers starting with a digit', function() {
     expect(exprToMQL.bind(null, '1two + 3four')).to.throw(
       /Variable names cannot start with a number/
     );
   });
-  it('prioritises parenthesis correctly', function() {
+
+  it('priorities parenthesis correctly', function() {
     const mql = exprToMQL('(3 - 4) * 5');
-    expect(mql).to.be.deep.equal({ $multiply: [{ $subtract: [3, 4] }, 5] });
+    expect(mql).to.be.deep.equal({
+      $multiply: [
+        { $subtract: [{ $literal: 3 }, { $literal: 4 }] },
+        { $literal: 5 }
+      ]
+    });
   });
+
   it('supports field paths in dot notation', function() {
     const mql = exprToMQL('foo.bar / 2.1');
-    expect(mql).to.be.deep.equal({ $divide: ['$foo.bar', 2.1] });
+    expect(mql).to.be.deep.equal({ $divide: ['$foo.bar', { $literal: 2.1 }] });
   });
+
   it('throws on function syntax', function() {
     expect(exprToMQL.bind(null, '1 + sum(3, 4)')).to.throw(
       /Invalid node type "CallExpression"/
     );
   });
+
   describe('examples', function() {
     const examples = [
-      { input: '1', output: 1 },
-      { input: '+1', output: 1 },
-      { input: '-1', output: -1 },
-      { input: '--1', output: 1 },
-      { input: '---1', output: -1 },
-      { input: '----1', output: 1 },
-      { input: '++++++1', output: 1 },
+      { input: '1', output: { $literal: 1 } },
+      { input: '+1', output: { $literal: 1 } },
+      { input: '-1', output: { $literal: -1 } },
+      { input: '--1', output: { $literal: 1 } },
+      { input: '---1', output: { $literal: -1 } },
+      { input: '----1', output: { $literal: 1 } },
+      { input: '++++++1', output: { $literal: 1 } },
       { input: 'foo', output: '$foo' },
       { input: '+foo', output: '$foo' },
-      { input: '-foo', output: { $multiply: [-1, '$foo'] } },
+      { input: '-foo', output: { $multiply: [{ $literal: -1 }, '$foo'] } },
       { input: 'foo.bar', output: '$foo.bar' },
-      { input: '-foo.bar', output: { $multiply: [-1, '$foo.bar'] } },
-      { input: '-"foo bar"', output: { $multiply: [-1, '$foo bar'] } },
+      {
+        input: '-foo.bar',
+        output: { $multiply: [{ $literal: -1 }, '$foo.bar'] }
+      },
+      {
+        input: '-"foo bar"',
+        output: { $multiply: [{ $literal: -1 }, '$foo bar'] }
+      },
       {
         input: 'foo--bar',
-        output: { $subtract: ['$foo', { $multiply: [-1, '$bar'] }] }
+        output: {
+          $subtract: ['$foo', { $multiply: [{ $literal: -1 }, '$bar'] }]
+        }
       },
       {
         input: '"foo"--"bar"',
-        output: { $subtract: ['$foo', { $multiply: [-1, '$bar'] }] }
+        output: {
+          $subtract: ['$foo', { $multiply: [{ $literal: -1 }, '$bar'] }]
+        }
       },
-      { input: '1 + 2', output: { $sum: [1, 2] } },
-      { input: '1 / foo', output: { $divide: [1, '$foo'] } },
+      { input: '1 + 2', output: { $sum: [{ $literal: 1 }, { $literal: 2 }] } },
+      { input: '1 / foo', output: { $divide: [{ $literal: 1 }, '$foo'] } },
       {
         input: 'foo.bar - bar.baz',
         output: { $subtract: ['$foo.bar', '$bar.baz'] }
@@ -82,8 +112,8 @@ describe('exprToMQL', function() {
         input: '(foo * 1.5) - bar + (foo.bar / 2)',
         output: {
           $sum: [
-            { $subtract: [{ $multiply: ['$foo', 1.5] }, '$bar'] },
-            { $divide: ['$foo.bar', 2] }
+            { $subtract: [{ $multiply: ['$foo', { $literal: 1.5 }] }, '$bar'] },
+            { $divide: ['$foo.bar', { $literal: 2 }] }
           ]
         }
       }

--- a/test/traverse-ast.spec.js
+++ b/test/traverse-ast.spec.js
@@ -10,11 +10,13 @@ describe('Traverse AST', function() {
         Array.from(traverseAST(null, { traversalMode: 'foofix' }))
       ).to.throw(/Invalid traversal mode/);
     });
+
     TRAVERSAL_MODES.forEach(mode => {
       it(`accepts traversal mode ${mode}`, function() {
         expect(() => Array.from(traverseAST(null, mode))).to.not.throw();
       });
     });
+
     it('traverses a simple binary expression in prefix mode', function() {
       const tree = jsep('foo + bar');
       const result = Array.from(traverseAST(tree, { traversalMode: 'prefix' }));
@@ -29,6 +31,7 @@ describe('Traverse AST', function() {
         'Identifier'
       ]);
     });
+
     it('traverses a simple binary expression in infix mode', function() {
       const tree = jsep('foo + bar');
       const result = Array.from(traverseAST(tree));
@@ -43,6 +46,7 @@ describe('Traverse AST', function() {
         'Identifier'
       ]);
     });
+
     it('traverses a simple binary expression in postfix mode', function() {
       const tree = jsep('foo + bar');
       const result = Array.from(
@@ -60,6 +64,7 @@ describe('Traverse AST', function() {
       ]);
     });
   });
+
   describe('error handling', function() {
     it('throws an error if a node does not have a type', function() {
       const brokenTree = {
@@ -71,6 +76,7 @@ describe('Traverse AST', function() {
       );
     });
   });
+
   describe('null / empty trees', function() {
     it('does not yield any values for a null tree', function() {
       const result = Array.from(traverseAST(null));
@@ -78,6 +84,7 @@ describe('Traverse AST', function() {
         .to.be.an('array')
         .with.lengthOf(0);
     });
+
     it('does not yield any values for a tree from an empty string', function() {
       const tree = jsep('');
       const result = Array.from(traverseAST(tree));
@@ -86,6 +93,7 @@ describe('Traverse AST', function() {
         .with.lengthOf(0);
     });
   });
+
   describe('BinaryExpression', function() {
     it('traverses the left and right children', function() {
       const tree = jsep('1 + 2');
@@ -98,6 +106,7 @@ describe('Traverse AST', function() {
       expect(types).to.deep.equal(['Literal', 'BinaryExpression', 'Literal']);
     });
   });
+
   describe('UnaryExpression', function() {
     it('traverses the argument child', function() {
       const tree = jsep('-1');
@@ -110,12 +119,14 @@ describe('Traverse AST', function() {
       expect(types).to.deep.equal(['UnaryExpression', 'Literal']);
     });
   });
+
   describe('collapse MemberExpression nodes to a single Identifier', function() {
     it('collapses a one-level member node correctly', function() {
       const tree = jsep('foo.bar');
       const result = Array.from(traverseAST(tree));
       expect(result[0]).to.include({ type: 'Identifier', name: 'foo.bar' });
     });
+
     it('collapses a multi-level member nodes correctly', function() {
       const tree = jsep('foo.bar.baz.boom');
       const result = Array.from(traverseAST(tree));
@@ -127,6 +138,7 @@ describe('Traverse AST', function() {
         name: 'foo.bar.baz.boom'
       });
     });
+
     it('works inside an expression', function() {
       const tree = jsep('foo.bar + baz.boom');
       const result = Array.from(traverseAST(tree));

--- a/test/validate-ast.spec.js
+++ b/test/validate-ast.spec.js
@@ -9,6 +9,7 @@ describe('Validate AST', function() {
         const tree = jsep('foo + (16.3 * bar)');
         expect(validateAST.bind(null, tree)).to.not.throw();
       });
+
       it('throws when the AST includes an invalid node type', function() {
         const tree = jsep('round(16.334)');
         expect(validateAST.bind(null, tree)).to.throw(
@@ -16,6 +17,7 @@ describe('Validate AST', function() {
         );
       });
     });
+
     context('with custom node types', function() {
       it('validates correctly when the AST only includes valid node types', function() {
         const tree = jsep('1 - 3 * 5 + 9');
@@ -37,12 +39,14 @@ describe('Validate AST', function() {
       });
     });
   });
+
   describe('Binary Operators', function() {
     context('with default binary operators', function() {
       it('validates correctly when the AST only includes valid binary operators', function() {
         const tree = jsep('1 + 2 - 3 / 4 * 5');
         expect(validateAST.bind(null, tree)).to.not.throw();
       });
+
       it('throws when the AST includes an invalid binary operator', function() {
         const tree = jsep('1 + 2 - 3 ^ 4 * 5');
         expect(validateAST.bind(null, tree)).to.throw(
@@ -50,6 +54,7 @@ describe('Validate AST', function() {
         );
       });
     });
+
     context('with custom binary operators', function() {
       it('validates correctly when the AST only includes valid binary operators', function() {
         const tree = jsep('1 + 2 ^ 3 + 4');
@@ -59,6 +64,7 @@ describe('Validate AST', function() {
           })
         ).to.not.throw();
       });
+
       it('throws when the AST includes an invalid binary operator', function() {
         const tree = jsep('1 + 2 - 3 ^ 4 * 5');
         expect(
@@ -77,6 +83,7 @@ describe('Validate AST', function() {
         expect(validateAST.bind(null, tree)).to.not.throw();
       });
     });
+
     context('with custom unary operators', function() {
       it('validates correctly when the AST only includes valid unary operators', function() {
         const tree = jsep('-foo + (-bar)');
@@ -86,6 +93,7 @@ describe('Validate AST', function() {
           })
         ).to.not.throw();
       });
+
       it('throws when the AST includes an invalid unary operator', function() {
         const tree = jsep('-foo + (+bar)');
         expect(
@@ -96,12 +104,14 @@ describe('Validate AST', function() {
       });
     });
   });
+
   describe('Literal Types', function() {
     context('with default literal types', function() {
       it('validates correctly when the AST only includes valid literal types', function() {
         const tree = jsep('"bar" + 9.4 - "foo" + 16.111');
         expect(validateAST.bind(null, tree)).to.not.throw();
       });
+
       it('throws when the AST includes invalid literal types', function() {
         const tree = jsep('"bar" + true - null + undefined');
         expect(validateAST.bind(null, tree)).to.throw(
@@ -109,6 +119,7 @@ describe('Validate AST', function() {
         );
       });
     });
+
     context('with custom literal types', function() {
       it('validates correctly when the AST only includes valid literal types', function() {
         const tree = jsep('13 + true + 16.111');
@@ -118,6 +129,7 @@ describe('Validate AST', function() {
           })
         ).to.not.throw();
       });
+
       it('throws when the AST includes invalid literal types', function() {
         const tree = jsep('"bar" + true / 16');
         expect(


### PR DESCRIPTION
### Description:
- Return literal numbers within a `$literal` stage to produce a valid MQL expression
- Required as part of [CHARTS-10816](https://jira.mongodb.org/browse/CHARTS-10816) to correctly parse calculated fields that contain literal numbers
- A separate PR will be made in charts to update the package version of `expression-to-mql`, including these changes once this PR has been merged and published

``` ts
// current returned value (invalid MQL)
2 -> 2
1.5 -> 1.5
-3 -> -3

// updated returned value (valid MQL)
2 -> { $literal: 2 }
1.5 -> { $literal: 1.5 }
-3 -> { $literal: -3 }
```

### Changes:
- Refactored `literalExpressionFn` and `unaryExpressionFn` methods to return `$literal` stages
- Updated `exprToMQL` test cases to reflect these changes

### Charts Before:

https://github.com/user-attachments/assets/7f94e53c-fcbb-4a4a-a139-84e662e3ce28



### Charts After:
(manually updating the `epxression-to-mql` build in `node_modules`)

https://github.com/user-attachments/assets/5ccb7123-6bd4-49db-a555-f2fa97067203

